### PR TITLE
fix: relative path handling in Find-Item

### DIFF
--- a/PSItems/Public/Find-Item.ps1
+++ b/PSItems/Public/Find-Item.ps1
@@ -165,14 +165,14 @@
         Default { $Method = 'EnumerateFileSystemEntries' }
     }
 
-    # Resolve absolute path in case it is relative
-    [ref] $dummy = $null
-    $Path = $PSCmdlet.GetResolvedProviderPathFromPSPath($Path, $dummy)
-
     try {
+        # Resolve absolute path in case it is relative
+        [ref] $dummy = $null
+        $absolutePath = $PSCmdlet.GetResolvedProviderPathFromPSPath($Path, $dummy)
+
         # if more than one string was given use foreach (so if input $Name is a string array)
         foreach ($input in $Name) {
-            foreach ($item in [System.IO.Directory]::$($Method)($path, $input, $EnumerationOptions)) {
+            foreach ($item in [System.IO.Directory]::$($Method)($absolutePath, $input, $EnumerationOptions)) {
                 if ($As -eq 'FileInfo') { $file = [System.IO.FileInfo]::new($item) } else { $file = [string]::new($item) }
                 Write-Output $file
             }

--- a/PSItems/Public/Find-Item.ps1
+++ b/PSItems/Public/Find-Item.ps1
@@ -97,7 +97,7 @@
     [CmdletBinding()]
     [OutputType('System.String', 'System.IO.FileSystemInfo')]
     param (
-        # Path to search for files
+        # Path to search for files.  Defaults to current directory.
         [Parameter(Mandatory = $false, Position = 0)]
         [string]
         $Path = $pwd,
@@ -164,6 +164,10 @@
         'File' { $Method = 'EnumerateFiles' }
         Default { $Method = 'EnumerateFileSystemEntries' }
     }
+
+    # Resolve absolute path in case it is relative
+    [ref] $dummy = $null
+    $Path = $PSCmdlet.GetResolvedProviderPathFromPSPath($Path, $dummy)
 
     try {
         # if more than one string was given use foreach (so if input $Name is a string array)

--- a/PSItems/Public/Find-Item.ps1
+++ b/PSItems/Public/Find-Item.ps1
@@ -178,7 +178,8 @@
             }
         }
     } catch {
-        throw $_.Exception.Message
+        Write-Error $_
+        return
     }
 }
 

--- a/PSItems/Public/Find-Item.ps1
+++ b/PSItems/Public/Find-Item.ps1
@@ -168,8 +168,7 @@
     try {
         # Resolve absolute path in case it is relative
         [ref] $dummy = $null
-        $absolutePath = $PSCmdlet.GetResolvedProviderPathFromPSPath($Path, $dummy)
-
+        $absolutePath = $PSCmdlet.GetResolvedProviderPathFromPSPath($Path, $dummy)[0]
         # if more than one string was given use foreach (so if input $Name is a string array)
         foreach ($input in $Name) {
             foreach ($item in [System.IO.Directory]::$($Method)($absolutePath, $input, $EnumerationOptions)) {


### PR DESCRIPTION
By default if you pass a relative path to the .NET APIs, it will use [Environment]::CurrentDirectory as its base, not your actual PowerShell working directory.

The problem is that the two are almost never the same.

This changes it so that the entry path is resolved by PowerShell, not .NET.

<!--- Provide a general summary of your changes in the Title above -->

## Description

This resolves relative paths to absolute in PowerShell's working directory context instead of .NET's.

<!--- Describe your changes in detail -->

By default if you pass a relative path to the .NET APIs, it will use [Environment]::CurrentDirectory as its base, not your actual PowerShell working directory.

The problem is that the two are almost never the same.

This changes it so that the entry path is resolved by PowerShell, not .NET, by using [PSCmdlet.GetResolvedProviderPathFromPSPath](https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.pscmdlet.getresolvedproviderpathfrompspath?view=powershellsdk-7.4.0) to resolve the path.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#19

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It lets me specify relative paths to Find-Item.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran `Find-Item` manually:

| How | Example | Result |
|:----|:--------|:------|
| without a specified path | `Find-Item` | Works same as before |
| with a relative path | `Find-Item foo` | Searches `$PWD\foo` instead of `$HOME\foo` |
| with an absolute path | `Find-Item D:\github\cdonnellytx\foo` | Works same as before |
| with a PSPath | `Find-Item 'Microsoft.PowerShell.Core\FileSystem::D:\github\cdonnellytx\foo'` | Searches as if it was passed `D:\github\cdonnellytx\foo` |

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

